### PR TITLE
Authorization header

### DIFF
--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -104,7 +104,7 @@ def authenticated(f):
 
             if token:
                 user = auth.user_for_token(token)
-                if not user or not auth.check_scopes(
+                if user and not auth.check_scopes(
                         'access:services!service=downloadservice', user):
                     user = None
             else:

--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -104,7 +104,7 @@ def authenticated(f):
 
             if token:
                 user = auth.user_for_token(token)
-                if user and not auth.check_scopes(
+                if user is not None and not auth.check_scopes(
                         'access:services!service=downloadservice', user):
                     user = None
             else:

--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -92,7 +92,15 @@ def authenticated(f):
                     service. At this time, the downloadservice uses jupyterhub\
                     to control access to protected resources", 500
 
-            token = session.get("token") or request.args.get('token')
+            header = request.headers.get('Authorization')
+            if header and header.startswith('Bearer '):
+                header_token = header.split()[1]
+            else:
+                header_token = None
+
+            token = session.get("token") \
+                or request.args.get('token') \
+                or header_token
 
             if token:
                 user = auth.user_for_token(token)

--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -96,7 +96,7 @@ def authenticated(f):
 
             if token:
                 user = auth.user_for_token(token)
-                if not auth.check_scopes(
+                if not user or not auth.check_scopes(
                         'access:services!service=downloadservice', user):
                     user = None
             else:


### PR DESCRIPTION
Token usually are provided using the `Authorization` header. This allows retrieving the `Bearer` token to authenticate users when using the API.