### PR TITLE
Fix #26 upload download service certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ secret-env.sh
 example-file
 local-file-example
 restored-file-example
+certificate/

--- a/upload_certificate.sh
+++ b/upload_certificate.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+kubeconfig_file=/projects/k8s_config_file.yaml
+cabundle_file=certificate/cabundle.pem
+clientcert_file=certificate/x509up_u1000
+
+# Retrieving pods
+echo "RETRIEVING PODS"
+prefix="pod/"
+staging_pod_fullname=$(kubectl --kubeconfig $kubeconfig_file get pod -n jh-staging-system -o name | grep staging-hub)
+production_pod_fullname=$(kubectl --kubeconfig $kubeconfig_file get pod -n jh-prod-system -o name | grep prod-hub)
+staging_pod=${staging_pod_fullname#"$prefix"}
+production_pod=${production_pod_fullname#"$prefix"}
+echo Staging pod : ${staging_pod}
+echo Production pod : ${staging_pod}
+
+# UPLOAD
+# Staging
+echo
+echo STAGING UPLOAD ...
+echo Uploading cabundle file \'$cabundle_file\' to staging
+kubectl --kubeconfig $kubeconfig_file cp -n jh-staging-system $cabundle_file "${staging_pod}:/downloadservice-data/dcache_cabundle.pem"
+echo Uploading clientcert file \'$clientcert_file\' to staging
+kubectl --kubeconfig $kubeconfig_file cp -n jh-staging-system $clientcert_file "${staging_pod}:/downloadservice-data/dcache_clientcert.crt"
+
+# Production
+echo
+echo PRODUCTION UPLOAD ...
+echo Uploading cabundle file \'$cabundle_file\' to production
+kubectl --kubeconfig $kubeconfig_file cp -n jh-prod-system $cabundle_file "${production_pod}:/downloadservice-data/dcache_cabundle.pem"
+echo Uploading clientcert file \'$clientcert_file\' to production
+kubectl --kubeconfig $kubeconfig_file cp -n jh-prod-system $clientcert_file "${production_pod}:/downloadservice-data/dcache_clientcert.crt"
+
+# Finish
+echo
+echo Upload complete !


### PR DESCRIPTION
Fixes #26 

I decided to create a small script which allows uploading certificates to the `downloadservice`. Not sure whether this script should be in this repository or in `cta-epfl/flux-jh`.

For now, it is pretty simple and extracts both `staging` and `prod` hub pods and upload the certificate in a PV mounted in the hub under `/downloadservice-data`. See https://github.com/cta-epfl/flux-jh/compare/910d49db712b5a24c1c9be85d89b92195327a1ce...147bf0415f7add02d9eb80c12fbc526134e36c17.

This is the easiest way to upload certificates without managing another layer of security inside the `downloadservice`. In the future we could add some additional parameters to the script but is it should only be used by a single user for now, it might be enough.