### PR TITLE
Fix base urls for `list` endpoint, from local to public name

### DIFF
--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -81,6 +81,7 @@ def create_app():
     app.secret_key = app.config['SECRET_KEY']
 
     app.config['CTACS_URL'] = os.getenv('CTACS_URL', '')
+    app.config['JH_BASE_URL'] = os.getenv('JH_BASE_URL', '').strip('/')
 
     app.config['CTADS_UPSTREAM_ENDPOINT'] = \
         os.getenv('CTADS_UPSTREAM_ENDPOINT',
@@ -292,7 +293,7 @@ def list_dir(user, path):
                 '', entry['href'])
 
             entry['url'] = '/'.join([
-                up.scheme + ':/', up.netloc,
+                app.config['JH_BASE_URL'] or (up.scheme + ':/', up.netloc),
                 re.sub(path, '', up.path).strip('/'), entry['href']
             ])
 

--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -293,7 +293,7 @@ def list_dir(user, path):
                 '', entry['href'])
 
             entry['url'] = '/'.join([
-                app.config['JH_BASE_URL'] or (up.scheme + ':/', up.netloc),
+                app.config['JH_BASE_URL'] or up.scheme + '://' + up.netloc,
                 re.sub(path, '', up.path).strip('/'), entry['href']
             ])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "downloadservice"
-version = "0.5.4"
+version = "0.5.5"
 description = ""
 authors = ["Volodymyr Savchenko <contact@volodymyrsavchenko.com>"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ def app():
         "TESTING": True,
         "CTADS_DISABLE_ALL_AUTH": True,
         "DEBUG": True,
+        "JH_BASE_URL": "https://app",
         'CTADS_UPSTREAM_ENDPOINT':
             f'http://{webdav_server_host}:{str(webdav_server_port)}/',
         'CTADS_UPSTREAM_BASEPATH': '',

--- a/tests/test_updown.py
+++ b/tests/test_updown.py
@@ -21,8 +21,8 @@ def test_list(app: Any, client: Any):
         r = client.get(url_for('list_dir', path="lst"))
         assert r.status_code == 200
 
-        expected_urls = ['http://app/list/lst/',
-                         'http://app/list/lst/users/']
+        expected_urls = ['https://app/list/lst/',
+                         'https://app/list/lst/users/']
         expected_hrefs = ['lst/',
                           'lst/users/']
 


### PR DESCRIPTION
Fix invalid `urls returned by `list_dir`command. Before, it returned the local url instead of the public url.

Before:
```python
before=[
  {'href': 'lst/', 'type': 'directory', 'url': 'http://jupyterhub-prod-hub/list/lst/'},
  {'href': 'lst/users/', 'type': 'directory', 'url': 'http://jupyterhub-prod-hub/list/lst/users/'}
]
```

Now:
```python
after=[
  {'href': 'lst/', 'type': 'directory', 'url': 'https://platform.cta.cscs.ch/list/lst/'},
  {'href': 'lst/users/', 'type': 'directory', 'url': 'https://platform.cta.cscs.ch/list/lst/users/'}
]
```