### PR TITLE
Auth api return json response

### DIFF
--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -169,6 +169,8 @@ def authenticated(f):
 
             if user:
                 return f(user, *args, **kwargs)
+            elif request.headers.get("Content-Type").lower() == "application/json":
+                return {'message': 'Invalid or missing Bearer token'}, 401
             else:
                 # redirect to login url on failed auth
                 state = auth.generate_state(next_url=request.path)

--- a/downloadservice/app.py
+++ b/downloadservice/app.py
@@ -167,9 +167,10 @@ def authenticated(f):
             else:
                 user = None
 
+            content_type = request.headers.get("Content-Type")
             if user:
                 return f(user, *args, **kwargs)
-            elif request.headers.get("Content-Type").lower() == "application/json":
+            elif content_type and content_type.lower() == "application/json":
                 return {'message': 'Invalid or missing Bearer token'}, 401
             else:
                 # redirect to login url on failed auth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "downloadservice"
-version = "0.7.10"
+version = "0.7.11"
 description = ""
 authors = ["Volodymyr Savchenko <contact@volodymyrsavchenko.com>"]
 

--- a/tests/test_ctadata.py
+++ b/tests/test_ctadata.py
@@ -96,6 +96,27 @@ def test_apiclient_upload_single_file(testing_download_service):
             assert os.path.isfile(remote_file)
 
 
+@pytest.mark.timeout(240)
+def test_apiclient_upload_single_large_file(testing_download_service):
+    with upstream_webdav_server() as (server_dir, _):
+        ctadata.APIClient.downloadservice = testing_download_service['url']
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            origin_file = f"{tmpdir}/local-file"
+            generate_random_file(origin_file, 1474801635)
+
+            remote_path = 'example-files/example-file'
+            r = ctadata.upload_file(origin_file, remote_path)
+
+            restored_file = f"{tmpdir}/restored-file"
+            ctadata.fetch_and_save_file(r['path'], restored_file)
+
+            assert hash_file(origin_file) == hash_file(restored_file)
+
+            remote_file = f"{server_dir}/lst/users/anonymous/{remote_path}"
+            assert os.path.isfile(remote_file)
+
+
 @pytest.mark.timeout(30)
 def test_apiclient_upload_invalid_path(testing_download_service):
     with upstream_webdav_server():


### PR DESCRIPTION
This PR changes the auth api return a json response when asked for. It will allow to have a proper `json` response when used by ctadata.